### PR TITLE
dummy import/export for GenotypeActivityBlock. PMT #96793

### DIFF
--- a/nynjaetc/treatment_activity/models.py
+++ b/nynjaetc/treatment_activity/models.py
@@ -160,6 +160,12 @@ class GenotypeActivityBlock(models.Model):
     def unlocked(self, user):
         return True
 
+    def to_json(self):
+        return {}
+
+    def import_from_dict(self, d):
+        pass
+
 
 class GenotypeActivityBlockForm(forms.ModelForm):
     class Meta:

--- a/nynjaetc/treatment_activity/tests/factories.py
+++ b/nynjaetc/treatment_activity/tests/factories.py
@@ -1,6 +1,8 @@
 import factory
 from nynjaetc.treatment_activity.models import (
-    TreatmentNode, TreatmentPath, TreatmentActivityBlock)
+    TreatmentNode, TreatmentPath, TreatmentActivityBlock,
+    GenotypeActivityBlock
+)
 
 
 def TreatmentNodeFactory(name="treatmentnode", type='RT', duration=0,
@@ -27,3 +29,7 @@ class TreatmentPathFactory(factory.DjangoModelFactory):
 
 class TreatmentActivityBlockFactory(factory.DjangoModelFactory):
     FACTORY_FOR = TreatmentActivityBlock
+
+
+class GenotypeActivityBlockFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = GenotypeActivityBlock

--- a/nynjaetc/treatment_activity/tests/test_models.py
+++ b/nynjaetc/treatment_activity/tests/test_models.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from .factories import (
-    TreatmentNodeFactory, TreatmentPathFactory, TreatmentActivityBlockFactory)
+    TreatmentNodeFactory, TreatmentPathFactory, TreatmentActivityBlockFactory,
+    GenotypeActivityBlockFactory
+)
 
 
 class TreatmentNodeTest(TestCase):
@@ -61,3 +63,27 @@ class TreatmentActivityBlockTest(TestCase):
         tn = TreatmentNodeFactory()
         tp = TreatmentPathFactory(tree=tn)
         self.assertEqual(list(tab.treatment_paths()), [tp])
+
+
+class GenotypeActivityBlockTest(TestCase):
+    def test_needs_submit(self):
+        gab = GenotypeActivityBlockFactory()
+        self.assertFalse(gab.needs_submit())
+
+    def test_edit_form(self):
+        gab = GenotypeActivityBlockFactory()
+        f = gab.edit_form()
+        self.assertIsNotNone(f)
+
+    def test_unlocked(self):
+        gab = GenotypeActivityBlockFactory()
+        self.assertTrue(gab.unlocked(None))
+
+    def test_to_json(self):
+        gab = GenotypeActivityBlockFactory()
+        self.assertEqual(gab.to_json(), {})
+
+    def test_import_from_dict(self):
+        gab = GenotypeActivityBlockFactory()
+        gab.import_from_dict({})
+        self.assertEqual(gab.to_json(), {})


### PR DESCRIPTION
The GenoTypeActivityBlock doesn't actually have any state; it's just a placeholder for a template file with JS. But without any kind of import/export json/dict functions, pagetree ignores it on a dump + import.

Just needs a couple dummy methods added to make sure that it gets included.
