### PR TITLE
:white_check_mark: smoketest for lessc

### DIFF
--- a/nynjaetc/main/smoke.py
+++ b/nynjaetc/main/smoke.py
@@ -2,6 +2,7 @@ from smoketest import SmokeTest
 from django.contrib.auth.models import User
 from quizblock.models import Question
 from django.conf import settings
+import os
 
 
 class DBConnectivity(SmokeTest):
@@ -28,3 +29,33 @@ class HRSA_ID_QuestionCheck(SmokeTest):
         id = settings.HRSA_ID_FIELD[-2:]
         q = Question.objects.get(id=id)
         self.assertTrue("HRSA unique ID" in q.text)
+
+
+def is_exe(fpath):
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+
+def check_fullpath(program):
+    if is_exe(program):
+        return program
+    return None
+
+
+def which(program):
+    fpath, fname = os.path.split(program)
+    if fpath:
+        return check_fullpath(program)
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None
+
+
+class LesscCheck(SmokeTest):
+    def test_lessc_exists(self):
+        """ we rely on lessc for styling, so let's
+        make sure the executable exists in our path """
+        self.assertTrue(which('lessc') is not None)


### PR DESCRIPTION
recently, after moving nynjaetc to patches, we discovered that
styling was messed up (PMT #98865).

Problem was that patches (being trusty) wasn't getting
lessc installed via Salt (there were explicit sections
for precise and lucid since npm stuff is so finicky, but
we hadn't included trusty yet). That was quickly fixed.

This adds a smoketest to make sure the lessc executable
exists and is in our path. So in the future, if we deploy
to a new host where lessc isn't there, it will fail. Or,
if an update on a server breaks lessc or moves it somewhere
not in our path, we will know about it quickly.