### PR TITLE
Fix reset password errors

### DIFF
--- a/nynjaetc/main/tests/factories.py
+++ b/nynjaetc/main/tests/factories.py
@@ -13,6 +13,7 @@ class UserFactory(factory.DjangoModelFactory):
     FACTORY_FOR = User
     username = factory.Sequence(lambda n: "user%03d" % n)
     is_staff = True
+    password = factory.PostGenerationMethodCall('set_password', 'test')
 
 
 class UserProfileFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
https://sentry.ccnmtl.columbia.edu/sentry-internal/nynjaetc/group/149/

* monkey patch referenced PasswordResetForm self.error_messages which were en vogue circa Django 1.5 (https://github.com/django/django/blob/1.5c2/django/contrib/auth/forms.py) and removed in 1.6.

* adding tests

* removing direct references to unusable password prefixes
