### PR TITLE
Fix: Reset password email not being sent

### DIFF
--- a/nynjaetc/main/models.py
+++ b/nynjaetc/main/models.py
@@ -234,6 +234,7 @@ def my_password_reset_form_save(
     # unencrypt emails
     for user in self.users_cache:
         user.email = user.userprofile.encrypted_email
+        user.save()
 
     # send emails
     self.original_save(domain_override,
@@ -245,6 +246,7 @@ def my_password_reset_form_save(
     # re-encrypt emails
     for user in self.users_cache:
         user.email = "*****"
+        user.save()
 PasswordResetForm.save = my_password_reset_form_save
 
 

--- a/nynjaetc/templates/registration/password_reset_email.html
+++ b/nynjaetc/templates/registration/password_reset_email.html
@@ -4,5 +4,5 @@ You have requested a user name reminder and/or to change your password for learn
 
 If you wish to change your password, please click the link provided below.
 
-{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uidb36=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}


### PR DESCRIPTION
Nynjaetc overrides the PasswordResetForm.save to account for encrypted emails, then calls the original save. This approach broke with a Django upgrade when a "users_cache" member variable was removed from the base class. Updating the override to account for the change.

The Django update that removes the users_cache was adopted in 1.6:
https://github.com/django/django/commit/2f4a4703e1931fadf5ed81387b26cf84caf5bef9#diff-e840e362abe9e625eee52d91897400bd

also fixing the reset confirm email to uidb64 from uidb36